### PR TITLE
user-roles-cache: properly escape the cache key to avoid Symfony erroring out on special keys

### DIFF
--- a/src/Authenticator/BearerUserProvider.php
+++ b/src/Authenticator/BearerUserProvider.php
@@ -99,7 +99,7 @@ class BearerUserProvider implements BearerUserProviderInterface, LoggerAwareInte
      */
     private function getUserRoles(?string $userIdentifier, array $scopes): array
     {
-        $cacheKey = json_encode([$this->userSession->getSessionCacheKey(), $userIdentifier, $scopes], JSON_THROW_ON_ERROR);
+        $cacheKey = Tools::escapeCacheKey(json_encode([$this->userSession->getSessionCacheKey(), $userIdentifier, $scopes], JSON_THROW_ON_ERROR));
 
         return $this->cachePool->get($cacheKey, function (ItemInterface $item) use ($scopes, $userIdentifier): array {
             $item->expiresAfter($this->userSession->getSessionTTL());

--- a/src/Helpers/Tools.php
+++ b/src/Helpers/Tools.php
@@ -25,4 +25,14 @@ class Tools
     {
         return preg_split('/\s+/', $jwt['scope'] ?? '', -1, PREG_SPLIT_NO_EMPTY);
     }
+
+    /**
+     * Escape a cache key string to be valid as a Symfony cache key.
+     */
+    public static function escapeCacheKey(string $input): string
+    {
+        // Always append a '.' since empty strings are also not allowed.
+        // For what isn't allowed see ItemInterface::RESERVED_CHARACTERS
+        return rawurlencode($input.'.');
+    }
 }

--- a/tests/ToolsTest.php
+++ b/tests/ToolsTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dbp\Relay\AuthBundle\Tests;
+
+use Dbp\Relay\AuthBundle\Helpers\Tools;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\CacheItem;
+use Symfony\Contracts\Cache\ItemInterface;
+
+class ToolsTest extends TestCase
+{
+    public function testEscapeCacheKey()
+    {
+        $this->assertSame('.', CacheItem::validateKey(Tools::escapeCacheKey('')));
+        $this->assertSame('%7B%7D%28%29%2F%5C%40%3A.', CacheItem::validateKey(Tools::escapeCacheKey(ItemInterface::RESERVED_CHARACTERS)));
+        $this->assertSame('%2Ffoo%2Fbar.', CacheItem::validateKey(Tools::escapeCacheKey('/foo/bar')));
+    }
+}


### PR DESCRIPTION
In case the user identifier contains special characters like @ the resulting cache key would not be considered valid by Symfony and it would throw 'contains reserved characters "{}()/\@:"'.

Work this around by passing everything through rawurlencode() first and also append something to allow empty strings as cahce key too.